### PR TITLE
Fix for milestone total percent

### DIFF
--- a/src/pages/briefs/[id]/applications/[applicationId].tsx
+++ b/src/pages/briefs/[id]/applications/[applicationId].tsx
@@ -241,6 +241,13 @@ const ApplicationPreview = (): JSX.Element => {
     window.location.reload();
   };
 
+  const totalPercent = milestones.reduce((sum, { amount }) => {
+    const percent = Number(
+      ((100 * (amount ?? 0)) / totalCostWithoutFee).toFixed(0)
+    );
+    return sum + percent;
+  }, 0);
+
   return (
     <>
       <div className="application-container">
@@ -269,7 +276,7 @@ const ApplicationPreview = (): JSX.Element => {
                 <p
                   className="text-base mt-2 underline cursor-pointer primary-text"
                   onClick={() =>
-                    redirect(`freelancers/${freelancer?.username}/`)
+                    router.push(`/freelancer/${freelancer?.username}/`)
                   }
                 >
                   View Full Profile
@@ -631,6 +638,7 @@ const ApplicationPreview = (): JSX.Element => {
           {isEditingBio && (
             <button
               className="primary-btn in-dark w-button"
+              disabled={totalPercent !== 100}
               onClick={() => updateProject()}
             >
               Update

--- a/src/pages/briefs/[id]/apply.tsx
+++ b/src/pages/briefs/[id]/apply.tsx
@@ -153,8 +153,12 @@ export const SubmitProposal = (): JSX.Element => {
     </div>
   );
 
-  const totalMilestonePercent =
-    (totalCostWithoutFee / Number(brief?.budget)) * 100;
+  const totalPercent = milestones.reduce((sum, { amount }) => {
+    const percent = Number(
+      ((100 * (amount ?? 0)) / totalCostWithoutFee).toFixed(0)
+    );
+    return sum + percent;
+  }, 0);
 
   return (
     <div className="flex flex-col gap-[2.5rem] text-base leading-[1.5]">
@@ -342,7 +346,7 @@ export const SubmitProposal = (): JSX.Element => {
       </div>
       <div className="buttons-container">
         <button
-          disabled={totalMilestonePercent !== 100}
+          disabled={totalPercent !== 100}
           className="primary-btn in-dark w-button"
           onClick={() => handleSubmit()}
         >


### PR DESCRIPTION
for the test case of this pr, when applying to a brief and setting milestones 
the expected behavior : all millstone percent total should be equal to 100 regardless of how much the freelancer put down for each mile stone, and the submit button should be disabled if not up to 100 percent

current behavior  : no check is being made for percentage total

same check has been applied for project update